### PR TITLE
Upgrade to bullseye

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,12 +22,12 @@
         "email": "andrew@reticu.li"
     },
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.0.9"
     },
     "multi_instance": true,
     "services": [
         "nginx",
-        "php7.3-fpm",
+        "php8.0-fpm",
         "mysql"
     ],
     "arguments": {


### PR DESCRIPTION
@tituspijean I would upgrade requirements to Bullseye as the helper seems to handle upgrading to PHP8 smoothly (don't ask me why... 😅 (it's maybe a légende urbaine))