### PR TITLE
Doc update: admin account creation

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -4,9 +4,9 @@ Before installing, read the [Hubzilla installation instructions](https://framagi
 ### Register a new domain and add it to YunoHost
 - Hubzilla requires a dedicated domain, so obtain one and add it using the YunoHost admin panel. **Domains -> Add domain**. As Hubzilla uses the full domain and is installed on the root, you can create a subdomain such as hubzilla.domain.tld. Don't forget to update your DNS if you manage them manually.
 
-## Ldap Admin user rights, logs and failed database updates
+### Admin user rights, logs and failed database updates
 
-- **For admin rights**: When installation is complete, you will need to visit your new hub's page and login with the **admin account email address** which was entered at the time of installation process. You should then be able to create your first channel and have the **admin rights** for the hub.
+- **Admin account**: When installation is complete, you must visit your new website and create the first account using the **admin's email address** (the admin is the YunoHost user which was chosen at the beginning of the installation process). You will then be able to create your first channel and have access to your website's **admin section**.
 
 - **Failing to get admin rights**: If the admin cannot access the admin settings at `https://hubzilla.example.com/admin` then you have to **manually add 4096** to the **account_roles** under **accounts** for that user in the **database through phpMyAdmin**.
 

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -4,9 +4,9 @@ Avant l'installation, lisez les [instructions d'installation de Hubzilla](https:
 ### Enregistrez un nouveau domaine et ajoutez-le à YunoHost
 - Hubzilla nécessite un domaine dédié, alors obtenez-en un et ajoutez-le à l'aide du panneau d'administration YunoHost. **Domaines -> Ajouter un domaine**. Comme Hubzilla utilise le domaine complet et est installé à la racine, vous pouvez créer un sous-domaine tel que hubzilla.domain.tld. N'oubliez pas de mettre à jour vos DNS si vous les gérez manuellement.
 
-## Droits d'utilisateur de l'administrateur Ldap, journaux et échec des mises à jour de la base de données
+### Droits d'utilisateur de l'administrateur, journaux et échec des mises à jour de la base de données
 
-- **Pour les droits d'administrateur** : lorsque l'installation est terminée, vous devrez visiter la page de votre nouveau hub et vous connecter avec l'**adresse mail du compte administrateur** qui a été saisi au moment du processus d'installation. Vous devriez alors pouvoir créer votre premier canal et disposer des **droits d'administrateur** pour le hub.
+- **Compte administrateur** : lorsque l'installation est terminée, vous devez vous rendre sur la page d'accueil de votre nouveau site et créer le premier compte en utilisant **l'adresse électronique de l' administrateur** (l'administrateur est l'utilisateur YunoHost qui a été choisi au début du processus d'installation). Vous pouvez ensuite créer votre premier canal et accéder à **l'interface d'administration** de votre site.
 
 - **Échec de l'obtention des droits d'administrateur** : si l'administrateur ne peut pas accéder aux paramètres d'administration sur `https://hubzilla.example.com/admin`, vous devez **ajouter manuellement 4096** aux **account_roles* * sous **comptes** pour cet utilisateur dans la **base de données via phpMyAdmin**.
 

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,0 +1,3 @@
+Installation of the application is now complete. You must now quickly go to your site and create the first account, which will be that of the administrator, using the email address of the user you chose before installation: **__EMAIL__**.
+
+You can of course change this address later in the account settings management interface on your site (https://__DOMAIN__/settings/account).

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,0 +1,3 @@
+L'installation de l'application est terminée. Vous devez maintenant vous rendre rapidement sur votre site et y créer le premier compte, qui sera celui de l'administrat·eur·ice, en utilisant impérativement l'adresse électronique de l'utilisat·eur·ice que vous avez choisi·e avant l'installation : **__EMAIL__**.
+
+Vous pourrez bien sûr modifier cette adresse par la suite dans l'interface de gestion des paramètres de compte sur votre site (https://__DOMAIN__/settings/account).


### PR DESCRIPTION
## Problem

- Doc says after install you need to connect to your Hubzilla website using the chosen admin YunoHost account credentials, while you actually need to create the Hubzilla admin account (using the mail address chosen prior before install) because LDAP is no longer used.

## Solution

- Modified ADMIN.MD and added a POST-INSTALL.MD message.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
